### PR TITLE
Use version folder as Publish Directory on Github Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/hugo-test'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site

--- a/config.yml
+++ b/config.yml
@@ -29,7 +29,7 @@ enableRobotsTXT:        true
 metaDataFormat:         "yaml"
 disableKinds:           ["404", "taxonomy", "term", "RSS"]
 
-publishDir:             "_site"
+publishDir:             "_site/1.0"
 
 module:
   mounts:


### PR DESCRIPTION
- Use version folder as Publish Directory on Github Pages